### PR TITLE
fix: use geist sans variable instead of classname

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -58,14 +58,9 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       </head>
 
       <body>
-        <main className={`${GeistSans.className} font-primary ${menloFont.className}`}>
+        <main className={`${GeistSans.variable} font-primary ${menloFont.variable}`}>
           {children}
           <Toaster />
-          {/* <style jsx global>{`
-          :root {
-            --font-geist-mono: ${GeistSans.style.fontFamily};
-          }
-        `}</style> */}
         </main>
       </body>
     </html>


### PR DESCRIPTION
https://www.npmjs.com/package/geist?activeTab=readme#with-tailwind-css