### PR TITLE
fix: keep in same tab if its an internal navigation

### DIFF
--- a/src/components/navigation-link.tsx
+++ b/src/components/navigation-link.tsx
@@ -17,18 +17,18 @@ export default function NavigationLink({
   target = '_blank',
   className,
 }: NavigationLinkProps) {
-  const isSameOrigin = useMemo(() => {
+  const [isSameOrigin, route] = useMemo(() => {
     try {
       const url = new URL(href)
-      return url.origin === window.location.origin
+      return [url.origin === window.location.origin, url.pathname]
     } catch (error) {
-      return false
+      return [false, '']
     }
   }, [href])
 
   return (
     <Link
-      href={href}
+      href={isSameOrigin ? route : href}
       target={isSameOrigin ? '_self' : target}
       rel={isSameOrigin ? '' : rel}
       className={cn(

--- a/src/constants/links.tsx
+++ b/src/constants/links.tsx
@@ -13,6 +13,7 @@ import { XGradient } from '@/components/icons/X'
 import { NavItem } from '@/types'
 
 export const DOCS_URL = `https://docs.river.build`
+export const RIVER_BUILD_URL = 'https://www.river.build'
 
 export const links = {
   X: 'https://twitter.com/buildonriver',
@@ -32,7 +33,7 @@ export const developersItems: NavItem[] = [
   {
     heading: 'Node Network Status',
     icon: <Satellite withGradient />,
-    url: 'https://www.river.build/status',
+    url: `${RIVER_BUILD_URL}/status`,
   },
   {
     heading: 'Documentation',
@@ -93,6 +94,6 @@ export const governanceItems: NavItem[] = [
   {
     heading: 'Delegation',
     icon: <Delegate />,
-    url: 'https://river.build/delegate',
+    url: `${RIVER_BUILD_URL}/delegate`,
   },
 ]


### PR DESCRIPTION
Previsouly, we was opening a new tab for river.build/delegate and status page. We want those pages to open in the same tab.