### PR TITLE
fix: escape hatch on embla wheel gesture plugin

### DIFF
--- a/src/components/runs-on-river.tsx
+++ b/src/components/runs-on-river.tsx
@@ -247,7 +247,8 @@ function RunsOnRiverDesktop({ cms }: { cms: SiteDataQuery }) {
                   plugins={[
                     WheelGesturesPlugin({
                       forceWheelAxis: 'x',
-                    }),
+                      // Its working fine, but types are broken
+                    }) as any,
                   ]}
                   setApi={setApi}
                   className="mx-auto h-full w-full"


### PR DESCRIPTION
Works fine, but seems like types are wrong (?)