### PR TITLE
feat: towns protocol banner

### DIFF
--- a/src/app/(no-wallet-required)/page.tsx
+++ b/src/app/(no-wallet-required)/page.tsx
@@ -13,8 +13,8 @@ const IndexPage = async () => {
 
   return (
     <>
-      <Header cms={cmsData} withNetworkStatusBanner />
-      <Hero cms={cmsData} withNetworkStatusBanner />
+      <Header cms={cmsData} withBanner />
+      <Hero cms={cmsData} withBanner />
       <Benefits cms={cmsData} />
       <Features cms={cmsData} />
       <RunsOnRiver cms={cmsData} />

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -11,7 +11,7 @@ import { Github } from '../icons/Github'
 import { Towns } from '../icons/Towns'
 import { X } from '../icons/X'
 import NavigationLink from '../navigation-link'
-import { NetworkStatusBanner } from '../network-status-banner'
+import { RiverIsNowTownsBanner } from '../river-is-now-towns-banner'
 import Community from './community'
 import Developers from './developers'
 import Governance from './governance'
@@ -19,16 +19,16 @@ import MobileDropownMenu from './mobile-dropdown-menu'
 
 type HeaderProps = {
   cms: SiteDataQuery
-  withNetworkStatusBanner?: boolean
+  withBanner?: boolean
 }
 
-export default function Header({ cms, withNetworkStatusBanner }: HeaderProps) {
+export default function Header({ cms, withBanner }: HeaderProps) {
   const { isMobile } = useWindowSize()
   const { isMobileMenuOpen, setIsMobileMenuOpen } = useAppStore()
 
   return (
     <header className="fixed top-0 z-50 flex w-full flex-col">
-      {withNetworkStatusBanner && <NetworkStatusBanner />}
+      {withBanner && <RiverIsNowTownsBanner />}
       <div className="relative">
         <div
           className={cn(

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -9,18 +9,12 @@ const AsciiHeroImage = dynamic(() => import('./ascii-hero-image'), { ssr: false 
 
 //! the heading and subheading on the Hero section doesn't follow the same size as the rest of the text on the page
 //! this is why we are not using the Typography component
-export default function Hero({
-  cms,
-  withNetworkStatusBanner,
-}: {
-  cms: SiteDataQuery
-  withNetworkStatusBanner?: boolean
-}) {
+export default function Hero({ cms, withBanner }: { cms: SiteDataQuery; withBanner?: boolean }) {
   return (
     <section
       className={cn(
-        'hero-glow relative flex w-full flex-col items-start justify-center overflow-x-clip bg-gray-90 py-24 pb-0  md:min-h-screen lg:items-center',
-        withNetworkStatusBanner ? 'pt-[100px] sm:pt-16' : 'pt-16',
+        'hero-glow relative flex w-full flex-col items-start justify-center overflow-x-clip bg-gray-90 py-24 pb-0 md:min-h-screen lg:items-center',
+        withBanner ? 'pt-[100px] sm:pt-16' : 'pt-16',
       )}
     >
       <div className="relative mx-auto flex w-full max-w-7xl flex-col justify-between gap-8 px-4 py-8 md:px-8 lg:flex-row lg:py-[58px] xl:gap-14 xl:py-[200px]">
@@ -69,7 +63,7 @@ export default function Hero({
 
         <AsciiHeroImage className="w-[90%] flex-1 items-center justify-center md:mx-auto md:w-[60%] lg:mx-0 lg:w-[55%]" />
       </div>
-      <div className="relative inset-x-0 h-[200px] w-full md:mt-0 md:h-[340px] ">
+      <div className="relative inset-x-0 h-[200px] w-full md:mt-0 md:h-[340px]">
         <Image
           src="/images/hero-wave.webp"
           alt="hero image"

--- a/src/components/river-is-now-towns-banner.tsx
+++ b/src/components/river-is-now-towns-banner.tsx
@@ -1,18 +1,19 @@
 'use client'
 
-import Satellite from '@/components/icons/Satellite'
+import { links } from '@/constants/links'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
+import { Towns } from './icons/Towns'
 import { Typography } from './ui/typography'
 
-export const NetworkStatusBanner = () => {
+export const RiverIsNowTownsBanner = () => {
   return (
     <div className="flex w-full items-center justify-center bg-[linear-gradient(to_left,#82E4A3_14.13%,#E48290_50%,#8C84F7_86%)] py-2 text-white">
-      <Link href="/status">
+      <Link href={links.Towns} target="_blank" rel="noopener noreferrer">
         <div className="flex items-center gap-2">
-          <Satellite height={16} width={16} />
+          <Towns height={16} width={16} />
           <Typography as="span" size="sm" className="font-medium">
-            Node Network Status
+            River is now Towns Protocol
           </Typography>
           <ChevronRight height={16} width={16} />
         </div>


### PR DESCRIPTION
Should close TOWNS-20330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the banner in the header to announce "River is now Towns Protocol" with a new icon and link, opening in a new tab for improved user experience.

- **Style**
  - Minor adjustments to the hero section’s layout for cleaner appearance.

- **Refactor**
  - Simplified and renamed banner-related properties and components for consistency across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->